### PR TITLE
only create thumbnails if they do not yet exist

### DIFF
--- a/myst_sphinx_gallery/images.py
+++ b/myst_sphinx_gallery/images.py
@@ -216,6 +216,10 @@ class Thumbnail:
             The path to the saved thumbnail image.
         """
         out_path = self.auto_output_path if out_path is None else Path(out_path)
+        if out_path.exists():
+            print(f"Thumbnail {out_path} already exists... skipping.")
+            return out_path
+
         ensure_dir_exists(out_path.parent)
         print(f"Saving thumbnail to {out_path}")
 


### PR DESCRIPTION
As mentioned in #8 the gallery currently re-creates all thumbnails every time the docs are re-rendered.
This is problematic if frequent re-renderings (e.g. with `sphinx-autobuild`) are used to update the docs while editing.

The implemented fix skips thumbnail creation in case the file already exists.